### PR TITLE
Znikający layout przy nawigacji po aktywowaniu compose'owego TextField 

### DIFF
--- a/app/src/main/java/com/intive/patronative/ui/activity/NavActivity.kt
+++ b/app/src/main/java/com/intive/patronative/ui/activity/NavActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidViewBinding
@@ -24,53 +25,43 @@ import com.intive.ui.PatronativeTheme
 class NavActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent {
-            HomeScreen()
-        }
 
-    }
-}
-
-@Composable
-fun HomeScreen() {
-    PatronativeTheme {
-        Scaffold(
-            topBar = {
-                PatronativeAppBar(
-                    title = {
-                        Text(
-                            text = stringResource(R.string.app_name),
-                            color = MaterialTheme.colors.primary
-                        )
-                    },
-                    actions = {
-                        IconButton(onClick = { }) {
-                            Icon(
-                                Icons.Outlined.Search,
-                                contentDescription = stringResource(R.string.search_icon_desc)
+        setContentView(R.layout.content_main).apply {
+            findViewById<ComposeView>(R.id.compose_view).setContent {
+                PatronativeTheme {
+                    PatronativeAppBar(
+                        title = {
+                            Text(
+                                text = stringResource(R.string.app_name),
+                                color = MaterialTheme.colors.primary
                             )
+                        },
+                        actions = {
+                            IconButton(onClick = { }) {
+                                Icon(
+                                    Icons.Outlined.Search,
+                                    contentDescription = stringResource(R.string.search_icon_desc)
+                                )
+                            }
+                            Spacer(modifier = Modifier.size(dimensionResource(id = R.dimen.appbar_icons_spacer_size)))
+                            IconButton(onClick = { }) {
+                                Icon(
+                                    Icons.Outlined.Person,
+                                    contentDescription = stringResource(R.string.profile_icon_desc)
+                                )
+                            }
+                            Spacer(modifier = Modifier.size(dimensionResource(id = R.dimen.appbar_icons_spacer_size)))
+                            IconButton(onClick = { }) {
+                                Icon(
+                                    Icons.Outlined.Dehaze,
+                                    contentDescription = stringResource(R.string.settings_icon_desc)
+                                )
+                            }
                         }
-                        Spacer(modifier = Modifier.size(dimensionResource(id = R.dimen.appbar_icons_spacer_size)))
-                        IconButton(onClick = { }) {
-                            Icon(
-                                Icons.Outlined.Person,
-                                contentDescription = stringResource(R.string.profile_icon_desc)
-                            )
-                        }
-                        Spacer(modifier = Modifier.size(dimensionResource(id = R.dimen.appbar_icons_spacer_size)))
-                        IconButton(onClick = { }) {
-                            Icon(
-                                Icons.Outlined.Dehaze,
-                                contentDescription = stringResource(R.string.settings_icon_desc)
-                            )
-                        }
-                    }
-                )
+                    )
+                }
             }
-        ) {
-            AndroidViewBinding(ContentMainBinding::inflate)
-           // FragmentAwareAndroidViewBinding(ContentMainBinding::inflate)
-           //Spacer(modifier = Modifier.size(20.dp))
         }
     }
 }
+

--- a/app/src/main/java/com/intive/patronative/ui/components/PatronativeAppBar.kt
+++ b/app/src/main/java/com/intive/patronative/ui/components/PatronativeAppBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.intive.patronative.R
@@ -21,18 +22,24 @@ fun PatronativeAppBar(
     actions: @Composable RowScope.() -> Unit = {}
 ) {
     val backgroundColor = MaterialTheme.colors.background
-    Column(
-        Modifier.background(backgroundColor.copy(alpha = 0.95f))
+    Surface(
+        modifier = Modifier.shadow(dimensionResource(id = R.dimen.appbar_elevation)),
+        elevation = dimensionResource(id = R.dimen.appbar_elevation)
     ) {
-        TopAppBar(
-            modifier = modifier,
-            title = { Row { title() } },
-            backgroundColor = MaterialTheme.colors.background,
-            elevation = dimensionResource(id = R.dimen.appbar_elevation),
-            actions = actions
-        )
+        Column(
+            Modifier.background(backgroundColor.copy(alpha = 0.95f))
+        ) {
+            TopAppBar(
+                modifier = modifier,
+                title = { Row { title() } },
+                backgroundColor = MaterialTheme.colors.background,
+                elevation = dimensionResource(id = R.dimen.appbar_elevation),
+                actions = actions
+            )
+        }
     }
 }
+
 
 @Preview
 @Composable

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -5,12 +5,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:clipChildren="false"
+    android:clipToPadding="false">
 
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/compose_view"
         android:layout_width="match_parent"
-        android:layout_height="120dp"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -20,12 +22,11 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginTop="56dp"
         app:defaultNavHost="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/compose_view"
         app:navGraph="@navigation/nav_graph" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.fragment.app.FragmentContainerView android:id="@+id/nav_host_fragment"
-    android:name="androidx.navigation.fragment.NavHostFragment"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    app:defaultNavHost="true"
-    app:navGraph="@navigation/nav_graph"
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto" />
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
+        android:layout_width="match_parent"
+        android:layout_height="120dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="56dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Zajmowałem się naprawą buga, w którym po aktywowaniu kontrolki TextField i próbie przejścia na inny ekran nie pojawia się layout. Problem tkwi w trzymaniu NavHostFragmentu w compose'owym AndroidViewBinding, które to nawet wg Googla fragmentów hostować nie powinno.