### PR TITLE
[FIX] Pokazanie widoku aktualnego tygodnia po powrocie do kalendarza

### DIFF
--- a/calendar/src/main/java/com/intive/calendar/fragments/CalendarHomeFragment.kt
+++ b/calendar/src/main/java/com/intive/calendar/fragments/CalendarHomeFragment.kt
@@ -34,4 +34,10 @@ class CalendarHomeFragment : Fragment() {
             }
         }
     }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshCalendar()
+        viewModel.showWeekView()
+    }
 }

--- a/calendar/src/main/java/com/intive/calendar/viewmodels/CalendarHomeViewModel.kt
+++ b/calendar/src/main/java/com/intive/calendar/viewmodels/CalendarHomeViewModel.kt
@@ -196,7 +196,7 @@ class CalendarHomeViewModel(
         _currentMonth.value = getCurrentMonth()
     }
 
-    private fun showWeekView() {
+    fun showWeekView() {
         _showWeekView.value = true
     }
 


### PR DESCRIPTION
Pokazywanie widoku aktualnego tygodnia po wyjściu z kalendarza do ekranu głównego za pomocą przycisku BACK i ponownym wejściu do kalendarza.